### PR TITLE
fix: documentation clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# ACSExamples
-Examples using the S3 compatible API to help users get onboard and start using ACS
+# ACSSetup
+Setup guides using the S3 compatible API to help users get onboard and start using ACS
 
 ### Language guides
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -1,6 +1,6 @@
-### S3 Examples (AWS CLI)
+### S3 Setup (AWS CLI)
 
-These examples demonstrate S3-compatible operations using the AWS CLI. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper configuration, error handling, and resource cleanup.
+These setup guides demonstrate S3-compatible operations using the AWS CLI. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper configuration, error handling, and resource cleanup.
 
 ### Prerequisites
 
@@ -10,7 +10,7 @@ These examples demonstrate S3-compatible operations using the AWS CLI. They show
 
 ### 1) Install required tools
 
-These examples require `aws` (CLI), `jq`, and `openssl`.
+These setup guides require `aws` (CLI), `jq`, and `openssl`.
 If you don't have them installed:
 
 ```bash
@@ -25,7 +25,7 @@ sudo ./aws/install
 
 ### 2) Configure your environment for an S3-compatible endpoint
 
-To use these examples with your S3-compatible object store, set the following standard AWS variables and one ACS-specific variable for the endpoint:
+To use these setup guides with your S3-compatible object store, set the following standard AWS variables and one ACS-specific variable for the endpoint:
 
 ```bash
 # Required: S3-compatible endpoint URL and region
@@ -91,9 +91,9 @@ export AWS_SECRET_ACCESS_KEY="YourActualSecretKey"
 source ./configure.sh
 ```
 
-**Note**: This option creates a custom `acs-examples` profile without affecting your default AWS configuration.
+**Note**: This option creates a custom `acs-setup` profile without affecting your default AWS configuration.
 
-### How client initialization works in these examples
+### How client initialization works in these setup guides
 
 - The scripts pass your endpoint explicitly with `--endpoint-url "$S3_ENDPOINT"`.
 - Credentials are resolved by the standard AWS chain (env vars, shared config, profiles, IAM, etc.).
@@ -102,11 +102,11 @@ source ./configure.sh
   - Precedence (highest to lowest):
     1) Explicit setting (CLI flag like `aws s3api --endpoint-url ...` plus `aws configure set s3.addressing_style ...`, or SDK client option such as `o.UsePathStyle`)
     2) SDK/shared config (`~/.aws/config` `s3.addressing_style`)
-    3) `S3_ADDRESSING_STYLE` environment variable (examples convenience)
+    3) `S3_ADDRESSING_STYLE` environment variable (setup convenience)
     4) Default: virtual-hosted-style
   - You can always override via an explicit CLI/config setting or client initialization option.
 
-### 3) Run the examples
+### 3) Run the setup guides
 
 Each script creates any required buckets/objects and cleans up after itself where applicable.
 
@@ -119,7 +119,7 @@ Each script creates any required buckets/objects and cleans up after itself wher
 ./s3_multipart_test.sh           # multipart upload (5 MiB + 2 MiB)
 
 # If you used Option C (custom profile):
-export AWS_PROFILE=acs-examples
+export AWS_PROFILE=acs-setup
 ./s3_basics.sh                   # (same commands as above)
 
 # Or run all tests at once (automatically configures custom profile)
@@ -129,7 +129,7 @@ export AWS_PROFILE=acs-examples
 ### Notes
 
 - **Default Profile (Options A & B)**: Uses your default AWS CLI configuration
-- **Custom Profile (Option C)**: Creates `acs-examples` profile without affecting your default AWS settings
+- **Custom Profile (Option C)**: Creates `acs-setup` profile without affecting your default AWS settings
 - **Addressing**: Virtual-hosted-style addressing is configured for optimal compatibility
 
 

--- a/examples/cli/configure.sh
+++ b/examples/cli/configure.sh
@@ -25,7 +25,7 @@ if [ -z "${AWS_REGION:-}" ] && [ -z "${AWS_DEFAULT_REGION:-}" ]; then
 fi
 
 # Configure AWS CLI with custom profile for ACS
-ACS_PROFILE="acs-examples"
+ACS_PROFILE="acs-setup"
 export AWS_PROFILE="$ACS_PROFILE"
 
 # Ensure .aws directory exists with proper permissions

--- a/examples/cli/run_all_tests.sh
+++ b/examples/cli/run_all_tests.sh
@@ -6,7 +6,7 @@
 # Note: Don't use 'set -e' here since we want to continue testing even if individual tests fail
 
 echo "========================================="
-echo "Running AWS CLI S3 Examples Test Suite"
+echo "Running AWS CLI S3 Setup Test Suite"
 echo "========================================="
 echo ""
 

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,6 +1,6 @@
-### S3 Examples (Go, AWS SDK v2)
+### S3 Setup (Go, AWS SDK v2)
 
-These examples demonstrate S3-compatible operations using the AWS SDK for Go v2. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper error handling and resource cleanup.
+These setup guides demonstrate S3-compatible operations using the AWS SDK for Go v2. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper error handling and resource cleanup.
 
 ### Prerequisites
 
@@ -10,7 +10,7 @@ These examples demonstrate S3-compatible operations using the AWS SDK for Go v2.
 ### 1) Initialize module and download deps
 
 ```bash
-cd /home/ec2-user/ACSExamples/examples/go
+cd /home/ec2-user/ACSSetup/examples/go
 go mod tidy
 ```
 
@@ -28,9 +28,9 @@ export AWS_ACCESS_KEY_ID="<YOUR_ACCESS_KEY_ID>"
 export AWS_SECRET_ACCESS_KEY="<YOUR_SECRET_ACCESS_KEY>"
 ```
 
-### 3) Run the examples
+### 3) Run the setup guides
 
-### How client initialization works in these examples
+### How client initialization works in these setup guides
 
 - The client sets `o.BaseEndpoint = aws.String(S3_ENDPOINT)` to target your endpoint.
 - Region is read from `AWS_REGION`/`AWS_DEFAULT_REGION` (fallback: `S3_REGION`).

--- a/examples/go/cmd/s3_basics/main.go
+++ b/examples/go/cmd/s3_basics/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"s3examples/internal/common"
+	"s3setup/internal/common"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/examples/go/cmd/s3_bucket_test/main.go
+++ b/examples/go/cmd/s3_bucket_test/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"s3examples/internal/common"
+	"s3setup/internal/common"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/examples/go/cmd/s3_copy_test/main.go
+++ b/examples/go/cmd/s3_copy_test/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"s3examples/internal/common"
+	"s3setup/internal/common"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/examples/go/cmd/s3_multipart_test/main.go
+++ b/examples/go/cmd/s3_multipart_test/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"s3examples/internal/common"
+	"s3setup/internal/common"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 

--- a/examples/go/cmd/s3_object_test/main.go
+++ b/examples/go/cmd/s3_object_test/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"s3examples/internal/common"
+	"s3setup/internal/common"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,4 +1,4 @@
-module s3examples
+module s3setup
 
 go 1.21
 

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,6 +1,6 @@
-### S3 Examples (boto3)
+### S3 Setup (boto3)
 
-These examples demonstrate S3-compatible operations using boto3, the AWS SDK for Python. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper error handling and resource cleanup.
+These setup guides demonstrate S3-compatible operations using boto3, the AWS SDK for Python. They showcase essential S3 operations including bucket management, object CRUD operations, copying, and multipart uploads with proper error handling and resource cleanup.
 
 ### Prerequisites
 
@@ -10,7 +10,7 @@ These examples demonstrate S3-compatible operations using boto3, the AWS SDK for
 ### 1) Create and activate a virtual environment
 
 ```bash
-cd /home/ec2-user/ACSExamples/examples/python
+cd /home/ec2-user/ACSSetup/examples/python
 python3 -m venv .venv
 source .venv/bin/activate
 ```
@@ -36,7 +36,7 @@ export AWS_ACCESS_KEY_ID="<YOUR_ACCESS_KEY_ID>"
 export AWS_SECRET_ACCESS_KEY="<YOUR_SECRET_ACCESS_KEY>"
 ```
 
-### 4) Run the examples
+### 4) Run the setup guides
 
 Each script creates any required buckets/objects and cleans up after itself where applicable.
 
@@ -48,7 +48,7 @@ python s3_copy_test.py       # copy an object within a bucket
 python s3_multipart_test.py  # multipart upload (5 MiB + 2 MiB)
 ```
 
-### How client initialization works in these examples
+### How client initialization works in these setup guides
 
 - The client is created with `endpoint_url=S3_ENDPOINT` to target your endpoint.
 - Region is taken from `AWS_REGION`/`AWS_DEFAULT_REGION` (fallback: `S3_REGION`).


### PR DESCRIPTION
- Changed naming to focus on the setup process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced setup-focused guides for S3 across Go and Python, including environment configuration and credential guidance.

- Documentation
  - Rebranded project and docs from “Examples” to “Setup,” updating headings, paths, and run instructions.
  - Expanded READMEs with setup prerequisites and environment variable guidance.

- Chores
  - Updated default AWS CLI profile name to acs-setup in scripts.
  - Revised test suite output titles to reflect setup terminology.
  - Renamed Go module to s3setup and specified Go toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->